### PR TITLE
Refactor/#28 CardViewModel 리팩토링

### DIFF
--- a/Picturethat/Picturethat.xcodeproj/project.pbxproj
+++ b/Picturethat/Picturethat.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		070B8DDF29D87B0100135BEA /* NotoSansKR-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 070B8DCF29D86C3800135BEA /* NotoSansKR-Light.otf */; };
 		070B8DE029D87B0100135BEA /* NotoSansKR-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 070B8DD029D86C3800135BEA /* NotoSansKR-Medium.otf */; };
 		070B8DE129D87B0100135BEA /* NotoSansKR-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 070B8DD129D86C3800135BEA /* NotoSansKR-Regular.otf */; };
+		0779FCD629E1530B003BA3FB /* CardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0779FCD529E1530B003BA3FB /* CardViewModel.swift */; };
 		078B618629DC47D900BA191C /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B618529DC47D900BA191C /* Card.swift */; };
 		078B618829DC4B2600BA191C /* ModelData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B618729DC4B2600BA191C /* ModelData.swift */; };
 		078B618C29DC522D00BA191C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 078B618B29DC522D00BA191C /* GoogleService-Info.plist */; };
@@ -45,6 +46,7 @@
 		070B8DD129D86C3800135BEA /* NotoSansKR-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-Regular.otf"; sourceTree = "<group>"; };
 		070B8DD729D86E0400135BEA /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		070B8DDB29D87A9D00135BEA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0779FCD529E1530B003BA3FB /* CardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CardViewModel.swift; path = PictureThat/Model/CardViewModel.swift; sourceTree = SOURCE_ROOT; };
 		078B618529DC47D900BA191C /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		078B618729DC4B2600BA191C /* ModelData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelData.swift; sourceTree = "<group>"; };
 		078B618B29DC522D00BA191C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				078B618529DC47D900BA191C /* Card.swift */,
 				078B619029DC5AA200BA191C /* Network.swift */,
 				078B618729DC4B2600BA191C /* ModelData.swift */,
+				0779FCD529E1530B003BA3FB /* CardViewModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -257,6 +260,7 @@
 				070B8DD829D86E0400135BEA /* Color+.swift in Sources */,
 				070B8DBE29D8472A00135BEA /* HomeView.swift in Sources */,
 				070B8DAC29D8455200135BEA /* PicturethatApp.swift in Sources */,
+				0779FCD629E1530B003BA3FB /* CardViewModel.swift in Sources */,
 				070B8DBC29D8471300135BEA /* PocaRanView.swift in Sources */,
 				07B5DAB329DD32D0004E389F /* CardView.swift in Sources */,
 				07B091F029DB08F0008C8A85 /* PocaRanToolBarContainerView.swift in Sources */,

--- a/Picturethat/Picturethat/HomeView/HomeView.swift
+++ b/Picturethat/Picturethat/HomeView/HomeView.swift
@@ -116,10 +116,7 @@ struct HomeView: View {
                         
                         
                         NavigationLink {
-                            PocaRanView(cardCount: self.$cardCount)
-                                .onAppear{
-                                    ModelData.shared.setCardDeck(cardCount: self.cardCount)
-                                }
+                            PocaRanView(cardViewModel: CardViewModel(cardCount: self.cardCount))
                         } label: {
                             Text("시작")
                                 .font(.noto(.bold, size: 16))

--- a/Picturethat/Picturethat/Model/CardViewModel.swift
+++ b/Picturethat/Picturethat/Model/CardViewModel.swift
@@ -1,0 +1,82 @@
+//
+//  CardViewModel.swift
+//  Picturethat
+//
+//  Created by Eric Lee on 2023/04/08.
+//
+
+import SwiftUI
+
+class CardViewModel: ObservableObject{
+    
+    @Published var cardViews: [CardView] = [CardView]()
+    @Published var cardCount: Int = 4
+    @Published var currentIndex: Int = 0
+    
+    var cards: [Card] = [Card]()
+    
+    func getCards(){
+        self.cards = [Card]()
+        
+        for index in 0..<self.cardCount{
+            
+            self.cards.append(Card(name: "\(index)", imgURL: "\(index) url"))
+            
+        }
+        
+    }
+    
+    // MARK: - Set Initial Card View
+    func setInitialCardViews(){
+        
+        getCards()
+        
+        self.cardViews = [CardView]()
+        
+        self.cardViews.append(CardView(card: ModelData.shared.cardDeck[0], isTopCard: true))
+        self.cardViews.append(CardView(card: ModelData.shared.cardDeck[1], isTopCard: false))
+        
+    }
+    
+    // MARK: - Set Next CardView
+    
+    func setNextCardView(){
+        
+        if self.currentIndex < self.cardCount - 1{
+            
+            self.cardViews.removeFirst()
+            self.cardViews[0].isTopCard = true
+            
+            if self.currentIndex < self.cardCount - 2{
+                
+                let card = self.cards[currentIndex+2]
+                
+                let newCardView = CardView(card: card, isTopCard: false)
+                
+                self.cardViews.append(newCardView)
+            }
+            
+            self.currentIndex += 1
+            
+        }
+        
+    }
+    
+    // MARK: - Set Prev CardView
+    
+    func setPrevCardView(){
+        
+        let card = self.cards[currentIndex-1]
+        let newCardView = CardView(card: card, isTopCard: true)
+        self.cardViews.insert(newCardView, at: 0)
+        
+        self.cardViews[1].isTopCard = false
+        
+        self.currentIndex -= 1
+        
+    }
+    
+    
+    
+    
+}

--- a/Picturethat/Picturethat/Model/CardViewModel.swift
+++ b/Picturethat/Picturethat/Model/CardViewModel.swift
@@ -19,7 +19,6 @@ class CardViewModel: ObservableObject{
     init(cardCount: Int) {
         
         self.cardCount = cardCount
-        self.getCards()
         self.setInitialCardViews()
         
     }
@@ -94,11 +93,11 @@ class CardViewModel: ObservableObject{
             self.currentIndex -= 1
             
         }
-        
-        
+
         
     }
     
+    // MARK: - is Top Card
     func isTopCard(cardView: CardView) -> Bool{
         
         guard let index = self.cardViews.firstIndex(where: { $0.id == cardView.id }) else {return false}
@@ -107,6 +106,19 @@ class CardViewModel: ObservableObject{
     }
     
     
+    // MARK: - is Fist Card
+    func isFirstCard() -> Bool{
+        return self.currentIndex == 0
+    }
     
+    // MARK: - is Last Card
+    func isLastCard() -> Bool{
+        return self.currentIndex == self.cardCount - 1
+    }
+    
+    // MARK: - NavBarText
+    func getNavBarText() -> String{
+        return "\(self.currentIndex)/\(self.cardCount)"
+    }
     
 }

--- a/Picturethat/Picturethat/Model/CardViewModel.swift
+++ b/Picturethat/Picturethat/Model/CardViewModel.swift
@@ -10,11 +10,21 @@ import SwiftUI
 class CardViewModel: ObservableObject{
     
     @Published var cardViews: [CardView] = [CardView]()
-    @Published var cardCount: Int = 4
     @Published var currentIndex: Int = 0
     
-    var cards: [Card] = [Card]()
+    private var cardCount: Int
+    private var cards: [Card] = [Card]()
     
+    // MARK: - init based on cardCount
+    init(cardCount: Int) {
+        
+        self.cardCount = cardCount
+        self.getCards()
+        self.setInitialCardViews()
+        
+    }
+    
+    // MARK: - Get Cards
     func getCards(){
         self.cards = [Card]()
         
@@ -66,13 +76,33 @@ class CardViewModel: ObservableObject{
     
     func setPrevCardView(){
         
-        let card = self.cards[currentIndex-1]
-        let newCardView = CardView(card: card, isTopCard: true)
-        self.cardViews.insert(newCardView, at: 0)
+        if self.currentIndex > 0 {
+            
+            
+            if self.currentIndex < cardCount - 1{
+            
+                self.cardViews.removeLast()
+                
+            }
+            
+            let card = self.cards[currentIndex-1]
+            let newCardView = CardView(card: card, isTopCard: true)
+            self.cardViews.insert(newCardView, at: 0)
+            
+            self.cardViews[1].isTopCard = false
+            
+            self.currentIndex -= 1
+            
+        }
         
-        self.cardViews[1].isTopCard = false
         
-        self.currentIndex -= 1
+        
+    }
+    
+    func isTopCard(cardView: CardView) -> Bool{
+        
+        guard let index = self.cardViews.firstIndex(where: { $0.id == cardView.id }) else {return false}
+        return index == 0
         
     }
     

--- a/Picturethat/Picturethat/PocaRanView/Helper/PocaRanControlBarView.swift
+++ b/Picturethat/Picturethat/PocaRanView/Helper/PocaRanControlBarView.swift
@@ -9,127 +9,50 @@ import SwiftUI
 
 struct PocaRanControlBarView: View {
     
-    @Binding var currentIndex: Int
-    @Binding var cardCount: Int
-    @Binding var cardViews: [CardView]
+    @EnvironmentObject var cardViewModel: CardViewModel
     
     var body: some View {
         HStack{
-            backButton(currentIndex: self.$currentIndex, cardCount: self.$cardCount, cardViews: self.$cardViews)
+            Button {
+                
+                self.cardViewModel.setPrevCardView()
+                    
+            } label: {
+                Image(systemName: "arrow.counterclockwise.circle.fill")
+                    .foregroundColor(
+                        self.cardViewModel.isFirstCard() ?
+                        Color.btnDisableColor:
+                        Color.btnEnableColor)
+            }
+            .disabled(self.cardViewModel.isFirstCard())
             
             Spacer()
             
-            nextButton(currentIndex: self.$currentIndex, cardCount: self.$cardCount, cardViews: self.$cardViews)
+            Button {
+                
+                self.cardViewModel.setNextCardView()
+                
+                
+            } label: {
+                Image(systemName: "arrow.forward.circle.fill")
+                    .foregroundColor( self.cardViewModel.isLastCard() ? Color.btnDisableColor: Color.btnEnableColor)
+            }
+            .disabled(self.cardViewModel.isLastCard())
+            
         }
         .padding()
         .background(Color.white.ignoresSafeArea(edges: .bottom))
     }
 }
 
-struct backButton: View{
-    @Binding var currentIndex: Int
-    @Binding var cardCount: Int
-    @Binding var cardViews: [CardView]
-
-    
-    var body: some View {
-        
-        Button {
-            
-            if self.currentIndex > 0 {
-                
-                if self.currentIndex < cardCount - 1{
-                
-                    self.cardViews.removeLast()
-                    
-                }
-                
-                setPreCard()
-                
-                currentIndex -= 1
-            }
-                
-        } label: {
-            Image(systemName: "arrow.counterclockwise.circle.fill")
-                .foregroundColor(self.currentIndex > 0 ? Color.btnEnableColor : Color.btnDisableColor)
-        }
-        .disabled(currentIndex == 0)
-        
-        
-    }
-    
-    // MARK: - Set Prev Card
-    private func setPreCard(){
-        
-        let card = ModelData.shared.cardDeck[currentIndex-1]
-        
-        let newCardView = CardView(card: card, isTopCard: true)
-        
-        self.cardViews.insert(newCardView, at: 0)
-        self.cardViews[1].isTopCard = false
-    }
-    
-}
-
-struct nextButton: View{
-    @Binding var currentIndex: Int
-    @Binding var cardCount: Int
-    @Binding var cardViews: [CardView]
-    
-    var body: some View {
-        
-        Button {
-            
-            if self.currentIndex < self.cardCount - 1 {
-                
-                
-                self.cardViews.removeFirst()
-                self.cardViews[0].isTopCard = true
-                
-                if self.currentIndex < (self.cardCount - 2) {
-                    //Get next Card
-                    self.setNextCard()
-                }
-                
-                self.currentIndex += 1
-                
-            }
-            
-            
-        } label: {
-            Image(systemName: "arrow.forward.circle.fill")
-                .foregroundColor(( self.currentIndex <  self.cardCount - 1) ? Color.btnEnableColor : Color.btnDisableColor)
-        }
-        .disabled(currentIndex == (cardCount - 1) )
-        
-        
-    }
-    
-    // MARK: - Set Next Card
-    private func setNextCard(){
-        let card = ModelData.shared.cardDeck[currentIndex+2]
-        
-        let newCardView = CardView(card: card, isTopCard: false)
-        
-        self.cardViews.append(newCardView)
-    }
-    
-}
 
 struct PocaRanControlBarView_Previews: PreviewProvider {
     
-    struct PocaRanControlBarViewContainer: View {
-        
-        @State var views: [CardView] = [CardView(card: ModelData.shared.cardDeck[0]),CardView(card: ModelData.shared.cardDeck[1])]
-        var body: some View {
-            PocaRanControlBarView(currentIndex: .constant(1), cardCount: .constant(4), cardViews: $views)
-        }
-        
+    static var previews: some View{
+        PocaRanControlBarView().environmentObject(CardViewModel(cardCount: 4))
     }
 
-    static var previews: some View {
-            PocaRanControlBarViewContainer()
-    }
+
 }
 
 

--- a/Picturethat/Picturethat/PocaRanView/Helper/PocaRanNavBarView.swift
+++ b/Picturethat/Picturethat/PocaRanView/Helper/PocaRanNavBarView.swift
@@ -10,8 +10,7 @@ import SwiftUI
 struct PocaRanNavBarView: View {
     @Environment(\.presentationMode) var presentationMode
     
-    @Binding var currentIndex: Int
-    @Binding var cardCount: Int
+    @EnvironmentObject var cardViewModel: CardViewModel
     
     var body: some View {
         HStack{
@@ -20,7 +19,7 @@ struct PocaRanNavBarView: View {
             
             Spacer()
             
-            Text("\(currentIndex)/\(cardCount)")
+            Text("\(self.cardViewModel.getNavBarText())")
                 .font(.noto(.medium, size: 20))
                 .foregroundColor(.black01)
             
@@ -36,7 +35,7 @@ struct PocaRanNavBarView: View {
 
 struct PocaRanNavBarView_Previews: PreviewProvider {
     static var previews: some View {
-        PocaRanNavBarView(currentIndex: .constant(1), cardCount: .constant(4))
+        PocaRanNavBarView().environmentObject(CardViewModel(cardCount: 4))
     }
 }
 

--- a/Picturethat/Picturethat/PocaRanView/Helper/PocaRanToolBarContainerView.swift
+++ b/Picturethat/Picturethat/PocaRanView/Helper/PocaRanToolBarContainerView.swift
@@ -9,17 +9,10 @@ import SwiftUI
 
 struct PocaRanToolBarContainerView<Content: View>: View {
     
-    @Binding var currentIndex: Int
-    @Binding var cardCount: Int
-    @Binding var cardViews: [CardView]
     let content: Content
     
-    
-    init(cardCount: Binding<Int>, currentIntdex: Binding<Int>, cardViews: Binding<[CardView]>, @ViewBuilder content: () -> Content) {
+    init(@ViewBuilder content: () -> Content) {
         
-        self._cardCount = cardCount
-        self._currentIndex = currentIntdex
-        self._cardViews = cardViews
         self.content = content()
         
     }
@@ -34,9 +27,9 @@ struct PocaRanToolBarContainerView<Content: View>: View {
                 .ignoresSafeArea()
             
             VStack(spacing: 0){
-                PocaRanNavBarView(currentIndex: self.$currentIndex, cardCount: self.$cardCount)
+                PocaRanNavBarView()
                 content.frame(maxWidth: .infinity, maxHeight: .infinity)
-                PocaRanControlBarView(currentIndex: self.$currentIndex, cardCount: self.$cardCount, cardViews: self.$cardViews)
+                PocaRanControlBarView()
             }
             
         }
@@ -46,26 +39,15 @@ struct PocaRanToolBarContainerView<Content: View>: View {
 }
 
 struct PocaRanToolBarContainerView_Previews: PreviewProvider {
-    
-    struct PocaRanToolBarContainerViewContainer: View {
-        @State var views: [CardView] = [CardView(card: ModelData.shared.cardDeck[0]),CardView(card: ModelData.shared.cardDeck[1])]
 
-        var body: some View {
-            PocaRanToolBarContainerView(cardCount: .constant(4), currentIntdex: .constant(1), cardViews: $views) {
-                VStack{
-                    
-                }
+    static var previews: some View{
+        PocaRanToolBarContainerView {
+            VStack{
+                
             }
         }
+        .environmentObject(CardViewModel(cardCount: 4))
     }
-    
 
-    static var previews: some View {
-        
-        PocaRanToolBarContainerViewContainer()
-                      
-                   
-    }
-    
-    
+
 }

--- a/Picturethat/Picturethat/PocaRanView/PocaRanView.swift
+++ b/Picturethat/Picturethat/PocaRanView/PocaRanView.swift
@@ -9,124 +9,72 @@ import SwiftUI
 
 struct PocaRanView: View {
     // MARK: - Properties
-    
-    @Binding var cardCount: Int
-    @State var currentIndex: Int = 0
-    
     //Swipe
     @State private var offset = CGSize.zero
     
-    
-    // MARK: - CARD Views
-    @State var cardViews: [CardView] = {
-        var views = [CardView]()
-        
-        views.append(CardView(card: ModelData.shared.cardDeck[0], isTopCard: true))
-        views.append(CardView(card: ModelData.shared.cardDeck[1], isTopCard: false))
-        
-        return views
-    }()
-    
+    // MARK: - CARD View Model
+    @StateObject var cardViewModel: CardViewModel
 
     // MARK: - body
     var body: some View {
         
-        PocaRanToolBarContainerView(cardCount: self.$cardCount, currentIntdex: self.$currentIndex, cardViews: self.$cardViews){
+        PocaRanToolBarContainerView{
             VStack{
                 ZStack{
                     
-                    ForEach(cardViews) { cardView in
+                    ForEach(self.cardViewModel.cardViews) { cardView in
                         cardView
-                            .zIndex(self.isTopCard(cardView: cardView) ? 1 : 0)
-                            .offset(self.isTopCard(cardView: cardView) ? CGSize(width: offset.width, height: offset.height * 0.4): CGSize.zero)
+                            .zIndex(self.cardViewModel.isTopCard(cardView: cardView) ? 1 : 0)
+                            .offset(self.cardViewModel.isTopCard(cardView: cardView) ? CGSize(width: offset.width, height: offset.height * 0.4): CGSize.zero)
                             .rotationEffect(
-                                .degrees(self.isTopCard(cardView: cardView) ? Double(offset.width / 40) : Double(0.0))
+                                .degrees(self.cardViewModel.isTopCard(cardView: cardView) ? Double(offset.width / 40) : Double(0.0))
                             )
                             .gesture(
                                 DragGesture()
                                     .onChanged{ gesture in
                                         
-                                        if self.isTopCard(cardView: cardView) && (currentIndex != cardCount){
+                                        if self.cardViewModel.isTopCard(cardView: cardView){
                                             offset = gesture.translation
                                         }
                                     }
                                     .onEnded{ _ in
-                                        if self.isTopCard(cardView: cardView){
+                                        if self.cardViewModel.isTopCard(cardView: cardView){
                                             swipeCard(width: offset.width)
                                         }
                                     }
                             )
-//                            .onTapGesture {
-//                                cardView.flipCard()
-//                            }
                     }
                     
                 }
             }
         }
         .toolbar(.hidden, for: .navigationBar)
-
+        .environmentObject(cardViewModel)
     
     }
 }
 
 struct PocaRanView_Previews: PreviewProvider {
     static var previews: some View {
-        PocaRanView(cardCount: .constant(4))
+        PocaRanView(cardViewModel: CardViewModel(cardCount: 4))
     }
 }
 
 extension PocaRanView{
-    // MARK: - Top Card
-    private func isTopCard(cardView: CardView) -> Bool{
-        
-        guard let index = cardViews.firstIndex(where: { $0.id == cardView.id }) else {return false}
-        return index == 0
-        
-    }
-    
     // MARK: - Swipe Card
     private func swipeCard(width: CGFloat) {
         switch width{
         case -500...(-150):
             offset = CGSize(width: -1000, height: 0)
-            self.moveCard()
+            self.cardViewModel.setNextCardView()
+            offset = .zero
         case 150...500:
             offset = CGSize(width: 1000, height: 0)
-            self.moveCard()
+            self.cardViewModel.setNextCardView()
+            offset = .zero
         default:
             offset = .zero
         }
-    }
-    
-    // MARK: - Move Card
-    private func moveCard(){
-        
-        if self.currentIndex < self.cardCount - 1 {
-            
-            
-            self.cardViews.removeFirst()
-            self.cardViews[0].isTopCard = true
-            
-            if self.currentIndex < self.cardCount - 2 {
-                //Get next Card
-                self.setNextCard()
-            }
-            
-            self.currentIndex += 1
-            
-        }
-        
-        self.offset = CGSize.zero
-    }
-    
-    // MARK: - Set Next Card
-    private func setNextCard(){
-        let card = ModelData.shared.cardDeck[currentIndex+2]
-        
-        let newCardView = CardView(card: card, isTopCard: false)
-        
-        self.cardViews.append(newCardView)
     }
     
 }


### PR DESCRIPTION
## 💡 Related Issue
#28 

## 📝 What's-New

- [x] CardViewModel 리팩토링 작업 
Published property wrapper: cardViews, currentIndex
cardViews: [CardView] - 2개의 CardView를 가지고 있음
currentIndex: Int - 최상단에 보여지고 있는 cardView의 index

- [x] CardViewModel 기능 
PocaRanView에서는 currentIndex기준 상단 2개의 CardView만 ZStack에 그립니다.
이전카드, 다음카드, 스와이프 등에 따라 변하는 CardView 2개에 대한 정보를 관리합니다. 

- [x] 관련 내용

선언) PocaRanView
StateObject var cardViewModel: CardViewModel

PocaRanView에서는 StateObject property wrapper로 cardViewModel를 초기화합니다
State property wrapper의 class 버전
ObservableObject 프로토콜을 준수한 타입만을 StateObject wrapper를 사용할 수 있음 
published 프로퍼티가 변하면 View를 새로 그려줌

초기화)  HomeView NavigationLink
PocaRanView(cardViewModel: CardViewModel(cardCount: self.cardCount))

HomeView의 CardCount를 사용해서 PocaRanView와 함께 PocaRanView의 프로퍼티인 CardViewModel를 초기화합니다.

사용) PocaRanView에서 EnvironmentObject로 cardModelData를 선언

PocaRanView body{ }.environmentObject(cardViewModel)

EnvironmentObject var cardViewModel: CardViewModel

HelperView(PocaRanControlBarView 등)는 EnvironmentObject로 선언된 cardViewModel에 접근할 수 있습니다.


